### PR TITLE
Don't ignore the config.json file in Vercel deploys

### DIFF
--- a/.vercelignore
+++ b/.vercelignore
@@ -1,6 +1,7 @@
 /*
 !api
 !build
+!config.json
 !public
 !src
 !package.json


### PR DESCRIPTION
Since `config.json` is depended upon, ignoring it causes the Vercel builds to fail. In this PR we add it to the allowlist.