### PR TITLE
Import the memory store explicitly

### DIFF
--- a/src/core/cache.ts
+++ b/src/core/cache.ts
@@ -1,3 +1,6 @@
+// @ts-ignore (TS7016) There is no type definition for this at DefinitelyTyped.
+import MemoryStore from 'cache-manager/lib/stores/memory';
+
 import cacheManager from 'cache-manager';
 
-export const cache = cacheManager.caching({ store: 'memory', max: 1000, ttl: 120 /*seconds*/ });
+export const cache = cacheManager.caching({ store: MemoryStore, max: 1000, ttl: 120 /*seconds*/ });


### PR DESCRIPTION
The `cache-manager` module uses a [dynamic import](https://github.com/BryanDonovan/node-cache-manager/blob/master/lib/caching.js#L28) to pull in some of its default stores (namely the `memory` and `none` stores). When we build the app, this dynamic import loses its reference directory (`./stores`) and can no longer find the module:

![image](https://user-images.githubusercontent.com/13243/149277161-9acecaca-e603-4635-b3f5-e828720a839f.png)

Instead, in this PR, we import it explicitly.