### PR TITLE
Repair rate limiter's IP getter

### DIFF
--- a/src/middleware/rateLimit.ts
+++ b/src/middleware/rateLimit.ts
@@ -5,7 +5,7 @@ import { wrapExpressHandler } from './wrapExpressHandler';
 // Just basic IP rate-limiting for now
 export const rateLimit = wrapExpressHandler(
     expressRateLimit({
-        max: ENV_RATE_LIMIT,
-        windowMs: ENV_RATE_LIMIT_INTERVAL,
+        max: ENV_RATE_LIMIT ?? 10,
+        windowMs: ENV_RATE_LIMIT_INTERVAL ?? 60,
     })
 );

--- a/src/middleware/rateLimit.ts
+++ b/src/middleware/rateLimit.ts
@@ -5,6 +5,8 @@ import { wrapExpressHandler } from './wrapExpressHandler';
 // Just basic IP rate-limiting for now
 export const rateLimit = wrapExpressHandler(
     expressRateLimit({
+        keyGenerator: (req) =>
+            (req.headers['x-real-ip'] as string | undefined) ?? req.socket.remoteAddress ?? 'UNKNOWN',
         max: ENV_RATE_LIMIT ?? 10,
         windowMs: ENV_RATE_LIMIT_INTERVAL ?? 60,
     })


### PR DESCRIPTION
The rate limiter middleware's default key is `req.ip` but there doesn't appear to be a property called `ip` on the request that we pass to it here. The actual object we give it is an `IncomingMessage` and the IP is available as `socket.remoteAddress` or in the headers.

In this PR, we teach the rate limiter middleware to source the IP address from the `x-real-ip` header first, and the `remoteAddress` on the socket second.