### PR TITLE
Revert returning signature in API methods w/o sending the transaction

### DIFF
--- a/packages/server/pages/api/transfer.ts
+++ b/packages/server/pages/api/transfer.ts
@@ -1,4 +1,4 @@
-import { PublicKey, Transaction } from '@solana/web3.js';
+import { PublicKey, sendAndConfirmRawTransaction, Transaction } from '@solana/web3.js';
 import type { NextApiRequest, NextApiResponse } from 'next';
 import base58 from 'bs58';
 import { signWithTokenFee } from '@solana/octane-core';
@@ -40,6 +40,18 @@ export default async function (request: NextApiRequest, response: NextApiRespons
             })),
             cache
         );
+
+        transaction.addSignature(
+            ENV_SECRET_KEYPAIR.publicKey,
+            Buffer.from(base58.decode(signature))
+        );
+
+        await sendAndConfirmRawTransaction(
+            connection,
+            transaction.serialize(),
+            {commitment: 'confirmed'}
+        );
+
         // Respond with the confirmed transaction signature
         response.status(200).send({ status: 'ok', signature });
     } catch (error) {


### PR DESCRIPTION
Previously I introduced an option to send transaction via your own RPC endpoint. However, it allows a "bad state" attack: user can request a signature (passing the simulation), then break the conditions for transaction success (for example, by withdrawing all of the tokens), then submit the transaction with no-checks option and previously received signature. The transaction will fail, but the transaction fee would be spent regardless.