### PR TITLE
Support for client-submitted transactions with ReCaptcha and allow-all validations

### DIFF
--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -21,6 +21,7 @@
         "@solana/octane-core": "*",
         "@solana/spl-token": "^0.2.0",
         "@solana/web3.js": "^1.48.0",
+        "axios": "^0.27.2",
         "bs58": "^5.0.0",
         "cache-manager": "^4.1.0",
         "commander": "^9.4.0",

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -2,3 +2,5 @@ export * from './cache';
 export * from './connection';
 export * from './env';
 export * from './middleware';
+export * from './reCaptcha';
+export * from './returnSignature';

--- a/packages/server/src/reCaptcha.ts
+++ b/packages/server/src/reCaptcha.ts
@@ -1,0 +1,48 @@
+import axios from "axios";
+
+type Event = {
+    token: string;
+    siteKey: string;
+    userAgent: string;
+    userIpAddress: string;
+    expectedAction: string;
+    hashedAccountId: string;
+}
+
+type RiskAnalysis = {
+    score: number;
+    reasons: string[];
+}
+
+type TokenProperties = {
+    valid: boolean;
+    invalidReason: string;
+    hostname: string;
+    action: string;
+    createTime: string;
+}
+
+type Assessment = {
+    name: string;
+    event: Event;
+    riskAnalysis: RiskAnalysis;
+    tokenProperties: TokenProperties;
+}
+
+export async function createAssessment(
+    projectId: string,
+    apiKey: string,
+    token: string,
+    key: string,
+    expectedAction: string,
+): Promise<Assessment> {
+    const url = `https://recaptchaenterprise.googleapis.com/v1/projects/${projectId}/assessments?key=${apiKey}`;
+    const response = (await axios.post(url, {
+        event: {
+            token: token,
+            siteKey: key,
+            expectedAction: expectedAction,
+        }
+    })).data;
+    return response as Assessment;
+}

--- a/packages/server/src/returnSignature.ts
+++ b/packages/server/src/returnSignature.ts
@@ -1,0 +1,42 @@
+import { createAssessment } from './reCaptcha';
+import { NextApiRequest } from 'next';
+
+type AllowAllConfig = {
+    type: 'allowAll';
+}
+
+type ReCaptchaConfig = {
+    type: 'reCaptcha';
+    reCaptchaProjectId: string;
+    reCaptchaSiteKey: string;
+    reCaptchaMinScore: number;
+}
+
+export type ReturnSignatureConfigField = AllowAllConfig | ReCaptchaConfig;
+
+export async function isReturnedSignatureAllowed(
+    request: NextApiRequest,
+    config: ReturnSignatureConfigField,
+): Promise<boolean> {
+    if (config.type === 'allowAll') {
+        return true;
+    }
+    if (config.type == 'reCaptcha') {
+        const reCaptchaToken = request.body?.reCaptchaToken;
+        if (typeof reCaptchaToken !== 'string') {
+            return false;
+        }
+        const reCaptchaAssessment = await createAssessment(
+            config.reCaptchaProjectId,
+            process.env.RECAPTCHA_API_KEY!,
+            reCaptchaToken,
+            config.reCaptchaSiteKey,
+            'octane'
+        );
+        if (!reCaptchaAssessment.tokenProperties.valid) {
+            return false;
+        }
+        return reCaptchaAssessment.riskAnalysis.score >= config.reCaptchaMinScore;
+    }
+    return true;
+}


### PR DESCRIPTION
Currently, Octane doesn't support transaction that are submitted from client. Such transactions could be used to drain fee payer by requesting many transactions, breaking the state for them (for example, by withdrawing all of the tokens), then submitting them to the network with `skip-preflight` options. Fee payers get charged, but transaction fails.

For some fee payers, spending these fees could be tolerable and, basically, "cost of doing business". This PR introduces a non-default config option. When enabled, `transfer` and `createAssociatedTokenAccount` endpoints return signatures, instead of submitting transactions.  `buildWhirlpoolsSwap` in this case will return pre-signed transaction, so `sendWhirlpoolsSwap` can be omitted.

The config option could be:
```
"returnSignature": {
    "type": "allowAll"
}
```

This way, all transactions will be allowed.

Alternatively, this config option will only pre-sign transactions if user passed reCaptcha validation:
```
"returnSignature": {
    "type": "reCaptcha",
    "reCaptchaProjectId": "",
    "reCaptchaSiteKey": "",
    "reCaptchaMinScore": 0.5
},
```

In this case, node operator has to set `RECAPTCHA_API_KEY` variable and pass `reCaptchaToken` with request.

