### PR TITLE
fix(core): add commonjs support for octane-core package

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -8,6 +8,7 @@
     "license": "Apache-2.0",
     "types": "dist/types/index.d.ts",
     "module": "dist/index.js",
+    "main": "dist/index.js",
     "files": [
         "dist",
         "src"


### PR DESCRIPTION
This change fixes `Cannot find module` error when using CommonJS.